### PR TITLE
Use extensionDependencies for older versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bugs": {
     "url": "https://github.com/jawandarajbir/react-vscode-extension-pack/issues"
   },
-  "extensionPack": [
+  "extensionDependencies": [
     "xabikos.ReactSnippets",
     "dbaeumer.vscode-eslint",
     "xabikos.javascriptsnippets",


### PR DESCRIPTION
Since older versions of VS Code does not support `extensionPack`, a newer version of your extension supporting `extensionDependencies` property with current vscode engine compatibility has to be published.

Can you please publish a new version of your extension with this change. Sorry for the confusion.

Thanks.