### PR TITLE
Set the correct vscode engine compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.3.0",
   "publisher": "jawandarajbir",
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.26.0"
   },
   "icon": "react.png",
   "galleryBanner": {


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support extensionPack property

Please publish a new version of your extension with this. Sorry for the confusion. Feel free to ping me for any questions.