### PR TITLE
Remove depreciated npm extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dbaeumer.vscode-eslint",
     "xabikos.javascriptsnippets",
     "jasonnutter.search-node-modules",
-    "eg2.vscode-npm-script",
     "christian-kohler.npm-intellisense",
     "christian-kohler.path-intellisense"
   ]


### PR DESCRIPTION
That should remove the depreciated npm extension properly.

Closes #5 